### PR TITLE
Avoid IllegalLocationConstraintException when creating S3 buckets in regions outside us-east-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Do stuff:
 (aws/invoke s3-client {:op :ListBuckets})
 ;; http-response is in the metadata
 (meta *1)
-(aws/invoke s3-client {:op :CreateBucket :request {:Bucket "my-unique-bucket-name"}})
+(aws/invoke s3-client {:op :CreateBucket :request {:Bucket "my-unique-bucket-name"
+                                                   :CreateBucketConfiguration {:LocationConstraint "us-west-2"}}})
 (aws/invoke s3-client {:op :ListBuckets})
 ```
 

--- a/examples/s3_examples.clj
+++ b/examples/s3_examples.clj
@@ -46,7 +46,11 @@
 ;; http-response is in the metadata
 (meta *1)
 
+;; create a bucket in the us-east-1 region
 (aws/invoke s3-client {:op :CreateBucket :request {:Bucket bucket-name}})
+;; create a bucket in the other regions (see https://stackoverflow.com/a/49174798 for why you need an additional entry) 
+(aws/invoke s3-client {:op :CreateBucket :request {:Bucket bucket-name
+                                                   :CreateBucketConfiguration {:LocationConstraint region-name}}})
 
 ;; now you should see the bucket you just added
 (aws/invoke s3-client {:op :ListBuckets})


### PR DESCRIPTION
An attempt to create a S3 bucket in regions outside us-east-1 throws IllegalLocationConstraintException. 

See https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html for the official documentation.

The suggested change was necessary for me to create a bucket in us-west-2 and should prevent others from tripping up on this peculiarity.