### PR TITLE
Credentials provider should rely on official AWS_SHARED_CREDENTIALS_FILE

### DIFF
--- a/src/cognitect/aws/credentials.clj
+++ b/src/cognitect/aws/credentials.clj
@@ -228,7 +228,8 @@
                                      (u/getProperty "aws.profile")
                                      "default")))
   ([profile-name]
-   (profile-credentials-provider profile-name (or (io/file (u/getenv "AWS_CREDENTIAL_PROFILES_FILE"))
+   (profile-credentials-provider profile-name (or (io/file (u/getenv "AWS_SHARED_CREDENTIALS_FILE"))
+                                                  (io/file (u/getenv "AWS_CREDENTIAL_PROFILES_FILE"))
                                                   (io/file (u/getProperty "user.home") ".aws" "credentials"))))
   ([profile-name ^File f]
    (cached-credentials-with-auto-refresh


### PR DESCRIPTION
As documentations [states](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) `AWS_SHARED_CREDENTIALS_FILE` should be used to point to `credentials` file. Java AWS SDK, Terraform, AWS SAM relies on the same variable. In that case, it's worth adding this environment variable to the credentials provider.

Thank you for your interest in contributing to Cognitect's aws-api!

As we incorporate this library into products and client projects, we
do not accept pull requests or patches.

We do, however, want to know how we can make it better, so please file
an issue at https://github.com/cognitect-labs/aws-api/issues.
