### PR TITLE
Add babashka support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@13.1
         with:
           cli: 1.12.0.1488
+          bb: 1.12.200
 
       - name: Cache clojure dependencies
         uses: actions/cache@v4
@@ -74,3 +75,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.INTEGRATION_TEST_AWS_SECRET_ACCESS_KEY }}
 
         run: clojure -M:dev:test-integration
+
+      - name: Run babashka tests
+        env:
+          # AWS_PROFILE is only required to comply with fixture check,
+          # it's not actually used to load credentials
+          AWS_PROFILE: aws-api-test
+          AWS_ACCESS_KEY_ID: ${{ secrets.INTEGRATION_TEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.INTEGRATION_TEST_AWS_SECRET_ACCESS_KEY }}
+
+        run: bb test-bb

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # aws-api
 
+## DEV
+
+* Add Babashka support
+* NOTE: the internal class `cognitect.aws.client.impl.Client` was removed
+
 ## 0.8.741 / 2025-04-17
 
 * Fix invalid signature for nonstandard host port [#263](https://github.com/cognitect-labs/aws-api/issues/263)

--- a/bb.edn
+++ b/bb.edn
@@ -2,11 +2,4 @@
  :tasks
  {test-bb {:doc  "Run Babashka tests"
            :extra-paths ["src" "test/src" "test/resources"]
-           :extra-deps {org.clojure/test.check        {:mvn/version "1.1.1"}
-                        com.cognitect.aws/endpoints   {:mvn/version "871.2.31.23"}
-                        com.cognitect.aws/autoscaling {:mvn/version "871.2.29.35"}
-                        com.cognitect.aws/ec2         {:mvn/version "871.2.31.23"}
-                        com.cognitect.aws/lambda      {:mvn/version "871.2.31.23"}
-                        com.cognitect.aws/s3          {:mvn/version "871.2.31.23"}
-                        com.cognitect.aws/ssm         {:mvn/version "871.2.31.23"}}
            :task bb-test-runner/run-tests}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,12 @@
+{:deps {com.cognitect.aws/api {:local/root "."}}
+ :tasks
+ {test-bb {:doc  "Run Babashka tests"
+           :extra-paths ["src" "test/src" "test/resources"]
+           :extra-deps {org.clojure/test.check        {:mvn/version "1.1.1"}
+                        com.cognitect.aws/endpoints   {:mvn/version "871.2.31.23"}
+                        com.cognitect.aws/autoscaling {:mvn/version "871.2.29.35"}
+                        com.cognitect.aws/ec2         {:mvn/version "871.2.31.23"}
+                        com.cognitect.aws/lambda      {:mvn/version "871.2.31.23"}
+                        com.cognitect.aws/s3          {:mvn/version "871.2.31.23"}
+                        com.cognitect.aws/ssm         {:mvn/version "871.2.31.23"}}
+           :task bb-test-runner/run-tests}}}

--- a/src/cognitect/aws/ec2_metadata_utils.clj
+++ b/src/cognitect/aws/ec2_metadata_utils.clj
@@ -4,7 +4,7 @@
 (ns ^:skip-wiki cognitect.aws.ec2-metadata-utils
   "Impl, don't call directly"
   (:require [clojure.string :as str]
-            [clojure.data.json :as json]
+            [cognitect.aws.json :as json]
             [clojure.core.async :as a]
             [cognitect.aws.http :as http]
             [cognitect.aws.util :as u]

--- a/src/cognitect/aws/http.clj
+++ b/src/cognitect/aws/http.clj
@@ -6,6 +6,7 @@
   (:require [clojure.edn :as edn]
             [clojure.core.async :as a]
             [clojure.string :as str]
+            [cognitect.aws.resources :as resources]
             [cognitect.aws.dynaload :as dynaload]))
 
 (set! *warn-on-reflection* true)
@@ -72,8 +73,7 @@
 
   Throws if more than one `cognitect_aws_http.edn` files are found."
   []
-  (let [cl   (.. Thread currentThread getContextClassLoader)
-        cfgs (enumeration-seq (.getResources cl "cognitect_aws_http.edn"))]
+  (let [cfgs (resources/resources "cognitect_aws_http.edn")]
     (case (count cfgs)
       0 'cognitect.aws.http.default/create
       1 (-> cfgs first read-config :constructor-var)

--- a/src/cognitect/aws/json.cljc
+++ b/src/cognitect/aws/json.cljc
@@ -1,0 +1,12 @@
+(ns ^:skip-wiki cognitect.aws.json
+  "Impl, don't call directly."
+  (:require #?(:bb  [cheshire.core]
+               :clj [clojure.data.json])))
+
+(defn read-str [string & {:as options}]
+  #?(:bb  (cheshire.core/parse-string string (:key-fn options))
+     :clj (clojure.data.json/read-str string options)))
+
+(defn write-str [x]
+  #?(:bb  (cheshire.core/generate-string x)
+     :clj (clojure.data.json/write-str x)))

--- a/src/cognitect/aws/protocols.clj
+++ b/src/cognitect/aws/protocols.clj
@@ -3,7 +3,7 @@
 
 (ns ^:skip-wiki cognitect.aws.protocols
   "Impl, don't call directly. "
-  (:require [clojure.data.json :as json]
+  (:require [cognitect.aws.json :as json]
             [clojure.string :as str]
             [cognitect.aws.util :as util])
   (:import (java.time ZoneOffset ZonedDateTime)))

--- a/src/cognitect/aws/resources.clj
+++ b/src/cognitect/aws/resources.clj
@@ -17,3 +17,8 @@
   "Returns the URL for a named resource, always using Clojure's base class loader."
   [n]
   (.getResource ^ClassLoader loader n))
+
+(defn resources
+  "Returns a seq of URLs for a named resource, always using Clojure's base class loader."
+  [n]
+  (enumeration-seq (.getResources ^ClassLoader loader n)))

--- a/src/cognitect/aws/resources.clj
+++ b/src/cognitect/aws/resources.clj
@@ -1,5 +1,5 @@
-(ns cognitect.aws.resources
-  (:require [clojure.java.io :as io])
+(ns ^:skip-wiki cognitect.aws.resources
+  "Impl, don't call directly."
   (:import (clojure.lang RT)))
 
 (def loader
@@ -16,4 +16,4 @@
 (defn resource
   "Returns the URL for a named resource, always using Clojure's base class loader."
   [n]
-  (io/resource n loader))
+  (.getResource ^ClassLoader loader n))

--- a/src/cognitect/aws/shape.clj
+++ b/src/cognitect/aws/shape.clj
@@ -22,7 +22,7 @@
                 like list, map, and structure, include shape-refs to refer to the other shapes
                 that represent the member shapes."
   (:refer-clojure :exclude [resolve])
-  (:require [clojure.data.json :as json]
+  (:require [cognitect.aws.json :as json]
             [cognitect.aws.util :as util]))
 
 (set! *warn-on-reflection* true)

--- a/src/cognitect/aws/util.clj
+++ b/src/cognitect/aws/util.clj
@@ -5,7 +5,7 @@
   "Impl, don't call directly."
   (:require [clojure.string :as str]
             [clojure.data.xml :as xml]
-            [clojure.data.json :as json]
+            [cognitect.aws.json :as json]
             [clojure.java.io :as io]
             [clojure.core.async :as a])
   (:import [java.time ZoneOffset ZonedDateTime]

--- a/test/src/bb_test_runner.clj
+++ b/test/src/bb_test_runner.clj
@@ -1,0 +1,50 @@
+(ns bb-test-runner
+  (:require [clojure.test :as t]
+            [cognitect.aws.api-test]
+            [cognitect.aws.client.shared-test]
+            [cognitect.aws.config-test]
+            [cognitect.aws.credentials-test]
+            [cognitect.aws.ec2-metadata-utils-test]
+            [cognitect.aws.endpoint-test]
+            [cognitect.aws.http-test]
+            [cognitect.aws.http.java-test]
+            [cognitect.aws.integration.error-codes-test]
+            [cognitect.aws.integration.s3-test]
+            [cognitect.aws.interceptors-test]
+            [cognitect.aws.protocols-test]
+            [cognitect.aws.protocols.rest-test]
+            [cognitect.aws.region-test]
+            [cognitect.aws.retry-test]
+            [cognitect.aws.shape-test]
+            [cognitect.aws.util-test]
+            [cognitect.client.impl-test]))
+
+; NOTE: some tests won't run in babashka:
+; cognitect.aws.http.default-test - all reify instances start with `babashka.impl.reify`, test won't pass
+; cognitect.aws.signers-test - requires loading AWS SDK, which is not supported (no Java libs)
+; cognitect.client.test-double-test - test double not supported in babashka
+
+(defn run-tests [& _args]
+  (let [{:keys [fail error] :as a}
+        (t/run-tests
+         'cognitect.aws.api-test
+         'cognitect.aws.client.shared-test
+         'cognitect.aws.config-test
+         'cognitect.aws.credentials-test
+         'cognitect.aws.ec2-metadata-utils-test
+         'cognitect.aws.endpoint-test
+         'cognitect.aws.http-test
+         'cognitect.aws.http.java-test
+         'cognitect.aws.integration.error-codes-test
+         'cognitect.aws.integration.s3-test
+         'cognitect.aws.interceptors-test
+         'cognitect.aws.protocols-test
+         'cognitect.aws.protocols.rest-test
+         'cognitect.aws.region-test
+         'cognitect.aws.retry-test
+         'cognitect.aws.shape-test
+         'cognitect.aws.util-test
+         'cognitect.client.impl-test)]
+    (when (or (pos? fail)
+              (pos? error))
+      (System/exit 1))))

--- a/test/src/bb_test_runner.clj
+++ b/test/src/bb_test_runner.clj
@@ -1,50 +1,41 @@
 (ns bb-test-runner
   (:require [clojure.test :as t]
-            [cognitect.aws.api-test]
-            [cognitect.aws.client.shared-test]
-            [cognitect.aws.config-test]
-            [cognitect.aws.credentials-test]
-            [cognitect.aws.ec2-metadata-utils-test]
-            [cognitect.aws.endpoint-test]
-            [cognitect.aws.http-test]
-            [cognitect.aws.http.java-test]
-            [cognitect.aws.integration.error-codes-test]
-            [cognitect.aws.integration.s3-test]
-            [cognitect.aws.interceptors-test]
-            [cognitect.aws.protocols-test]
-            [cognitect.aws.protocols.rest-test]
-            [cognitect.aws.region-test]
-            [cognitect.aws.retry-test]
-            [cognitect.aws.shape-test]
-            [cognitect.aws.util-test]
-            [cognitect.client.impl-test]))
+            [clojure.edn :as edn]))
+
+; Load dev dependencies from deps.edn
+(require '[babashka.deps :as deps])
+(deps/add-deps (edn/read-string (slurp "deps.edn"))
+               {:aliases [:dev]})
 
 ; NOTE: some tests won't run in babashka:
 ; cognitect.aws.http.default-test - all reify instances start with `babashka.impl.reify`, test won't pass
 ; cognitect.aws.signers-test - requires loading AWS SDK, which is not supported (no Java libs)
 ; cognitect.client.test-double-test - test double not supported in babashka
+(def test-namespaces
+  ['cognitect.aws.api-test
+   'cognitect.aws.client.shared-test
+   'cognitect.aws.config-test
+   'cognitect.aws.credentials-test
+   'cognitect.aws.ec2-metadata-utils-test
+   'cognitect.aws.endpoint-test
+   'cognitect.aws.http-test
+   'cognitect.aws.http.java-test
+   'cognitect.aws.integration.error-codes-test
+   'cognitect.aws.integration.s3-test
+   'cognitect.aws.interceptors-test
+   'cognitect.aws.protocols-test
+   'cognitect.aws.protocols.rest-test
+   'cognitect.aws.region-test
+   'cognitect.aws.retry-test
+   'cognitect.aws.shape-test
+   'cognitect.aws.util-test
+   'cognitect.client.impl-test])
 
 (defn run-tests [& _args]
-  (let [{:keys [fail error] :as a}
-        (t/run-tests
-         'cognitect.aws.api-test
-         'cognitect.aws.client.shared-test
-         'cognitect.aws.config-test
-         'cognitect.aws.credentials-test
-         'cognitect.aws.ec2-metadata-utils-test
-         'cognitect.aws.endpoint-test
-         'cognitect.aws.http-test
-         'cognitect.aws.http.java-test
-         'cognitect.aws.integration.error-codes-test
-         'cognitect.aws.integration.s3-test
-         'cognitect.aws.interceptors-test
-         'cognitect.aws.protocols-test
-         'cognitect.aws.protocols.rest-test
-         'cognitect.aws.region-test
-         'cognitect.aws.retry-test
-         'cognitect.aws.shape-test
-         'cognitect.aws.util-test
-         'cognitect.client.impl-test)]
+  (apply require test-namespaces)
+
+  (let [{:keys [fail error]}
+        (apply t/run-tests test-namespaces)]
     (when (or (pos? fail)
               (pos? error))
       (System/exit 1))))

--- a/test/src/cognitect/aws/credentials_test.cljc
+++ b/test/src/cognitect/aws/credentials_test.cljc
@@ -4,7 +4,6 @@
 (ns cognitect.aws.credentials-test
   (:require [clojure.test :as t :refer [deftest testing is]]
             [clojure.java.io :as io]
-            [clojure.tools.logging.test :refer [with-log logged?]]
             [cognitect.aws.client.shared :as shared]
             [cognitect.aws.credentials :as credentials]
             [cognitect.aws.util :as u]
@@ -37,15 +36,20 @@
     (testing "The chain provider returns nil if none of the providers returns credentials."
       (is (nil? (credentials/fetch (credentials/chain-credentials-provider [p1])))))))
 
-(deftest valid-credentials-test
-  (with-log
-    (credentials/valid-credentials nil "x provider")
-    (is (logged? 'cognitect.aws.credentials :debug (str "Unable to fetch credentials from x provider."))))
-  (with-log
-    (credentials/valid-credentials {:aws/access-key-id     "id"
-                                    :aws/secret-access-key "secret"}
-                                   "x provider")
-    (is (logged? 'cognitect.aws.credentials :debug (str "Fetched credentials from x provider.")))))
+; clojure.tools.logging.test not supported in babashka
+#?(:bb nil
+   :clj
+   (do
+     (require '[clojure.tools.logging.test :refer [with-log logged?]])
+     (deftest valid-credentials-test
+       (with-log
+        (credentials/valid-credentials nil "x provider")
+        (is (logged? 'cognitect.aws.credentials :debug (str "Unable to fetch credentials from x provider."))))
+       (with-log
+        (credentials/valid-credentials {:aws/access-key-id     "id"
+                                        :aws/secret-access-key "secret"}
+                                       "x provider")
+        (is (logged? 'cognitect.aws.credentials :debug (str "Fetched credentials from x provider.")))))))
 
 (deftest environment-credentials-provider-test
   (testing "required vars present"

--- a/test/src/cognitect/aws/protocols_test.clj
+++ b/test/src/cognitect/aws/protocols_test.clj
@@ -3,7 +3,7 @@
 
 (ns cognitect.aws.protocols-test
   "Test the protocols implementations."
-  (:require [clojure.data.json :as json]
+  (:require [cognitect.aws.json :as json]
             [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
@@ -484,7 +484,7 @@
     (is (submap? {:cognitect.anomalies/category :cognitect.anomalies/busy}
                  (aws.protocols/parse-http-error-response
                   {:status 400
-                   :body (util/->bbuf (json/json-str {:__type "ThrottlingException"}))})))
+                   :body (util/->bbuf (json/write-str {:__type "ThrottlingException"}))})))
     (is (submap? {:cognitect.anomalies/category :cognitect.anomalies/busy}
                  (aws.protocols/parse-http-error-response
                   {:status 400
@@ -503,8 +503,8 @@
                 "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
                 "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/#some-more-stuff"]]
     (doseq [data [{:headers {"x-amzn-errortype" code}}
-                  {:body (util/->bbuf (json/json-str {:__type code}))}
-                  {:body (util/->bbuf (json/json-str {:code code}))}
+                  {:body (util/->bbuf (json/write-str {:__type code}))}
+                  {:body (util/->bbuf (json/write-str {:code code}))}
                   {:body (util/->bbuf (str "<Error><Code>" code "</Code></Error>"))}
                   {:body (util/->bbuf (str "<ErrorResponse><Error><Code>" code "</Code></Error></ErrorResponse>"))}
                   {:body (util/->bbuf (str "<Response><Errors><Error><Code>" code "</Code></Error></Errors></Response>"))}]]

--- a/test/src/cognitect/aws/test/ec2_metadata_utils_server.clj
+++ b/test/src/cognitect/aws/test/ec2_metadata_utils_server.clj
@@ -3,8 +3,7 @@
 
 (ns cognitect.aws.test.ec2-metadata-utils-server
   "Modeled after com.amazonaws.util.EC2MetadataUtilsServer"
-  (:require [clojure.data.json :as json]
-            [cognitect.aws.client.shared :as shared]
+  (:require [cognitect.aws.json :as json]
             [cognitect.aws.ec2-metadata-utils :as ec2-metadata-utils]
             [cognitect.aws.util :as u]
             [org.httpkit.server :as http-server]))

--- a/test/src/cognitect/aws/test/utils.clj
+++ b/test/src/cognitect/aws/test/utils.clj
@@ -14,7 +14,7 @@
     (get props k)))
 
 (defn major-java-version []
-  (-> (System/getProperty "java.version") (str/split #"\.") first read-string))
+  (-> (System/getProperty "java.version") (str/split #"[\.-]") first read-string))
 
 (defmacro when-java11 [& body]
   (when (<= 11 (major-java-version))


### PR DESCRIPTION
Support running aws-api in babashka. Ignoring whitespaces during review is recommended.

- Conditional reader around JSON fns to support babashka (latest version of data.json doesn't work in babashka anymore)
- deftype -> reify (deftype implementing a Java interface is not supported by babashaka)
- Improve resource loading (ensure Clojure's class loader is used; workaround babashka bug)
- Run tests in babashka as well