### PR TITLE
Fix `rest-json` and `json` headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## DEV
 
 * Add http read timeout to IMDS requests [#267](https://github.com/cognitect-labs/aws-api/issues/267)
+* Fix `rest-json` and `json` protocol request headers [#168](https://github.com/cognitect-labs/aws-api/issues/168) [#241](https://github.com/cognitect-labs/aws-api/issues/241)
 
 ## 0.8.762 / 2025-08-05
 


### PR DESCRIPTION
`rest-json` and `json` protocols are not the same.

`rest-json` is defined by [1], and uses `application/json` content type.

`json` is a AWS-specific protocol defined by [2], that uses a custom `application/x-amz-json-1.0` or `application/x-amz-json-1.1` content type. It also requires the `X-Amz-Target` header.

Fixes #168 
Fixes #241

[1] https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html
[2] https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html and https://smithy.io/2.0/aws/protocols/aws-json-1_1-protocol.html