### PR TITLE
feat: Add `AWS_EC2_METADATA_SERVICE_ENDPOINT`

### DIFF
--- a/src/cognitect/aws/ec2_metadata_utils.clj
+++ b/src/cognitect/aws/ec2_metadata_utils.clj
@@ -42,8 +42,8 @@
 (defn get-host-address
   "Gets the EC2 (or ECS) metadata host address"
   []
-  (or (u/getenv ec2-metadata-service-override-env-var)
-      (u/getProperty ec2-metadata-service-override-system-property)
+  (or (u/getProperty ec2-metadata-service-override-system-property)
+      (u/getenv ec2-metadata-service-override-env-var)
       (when (in-container?) ecs-metadata-host)
       ec2-metadata-host))
 


### PR DESCRIPTION
resolves: https://github.com/cognitect-labs/aws-api/issues/293

All the documentation for AWS IAM Roles Anywhere references setting this environment variable, which is not recognised by the Cognitect AWS API even though the equivalent system property _is_. This PR adds support for the env var. I couldn't see any existing tests for this (very basic) functionality, so I have not added any new ones.

The Java system property takes priority over the env var, as that matches the behaviour that the Java SDK has.

Thank you for your interest in contributing to Cognitect's aws-api!

As we incorporate this library into products and client projects, we
do not accept pull requests or patches.

We do, however, want to know how we can make it better, so please file
an issue at https://github.com/cognitect-labs/aws-api/issues.
