### PR TITLE
Enhance test fixture to detect if AWS env var secrets are not set

### DIFF
--- a/test/src/cognitect/aws/integration/fixtures.clj
+++ b/test/src/cognitect/aws/integration/fixtures.clj
@@ -1,4 +1,5 @@
-(ns cognitect.aws.integration.fixtures)
+(ns cognitect.aws.integration.fixtures
+  (:require [clojure.string :as s]))
 
 (defn ensure-test-profile
   "Ensure AWS_PROFILE env var is aws-api-test
@@ -8,5 +9,7 @@
   (use-fixtures :once aux.integration/ensure-test-profile)"
   [f]
   (if (= "aws-api-test" (System/getenv "AWS_PROFILE"))
-    (f)
+    (if (s/blank? (System/getenv "AWS_ACCESS_KEY_ID"))
+      (println "AWS_* secret env vars not available, so not running integration tests.")
+      (f))
     (println "AWS_PROFILE is not configured, so not running integration tests.")))


### PR DESCRIPTION
Enhance test fixture to detect if AWS env var secrets are not set

Please make sure to follow our [contribution guidelines](https://github.com/cognitect-labs/aws-api/blob/main/README.md#contributing).
