### PR TITLE
Accept any value that satisfies `inst?` in `timestamp` shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # aws-api
 
+## DEV
+
+* Accept any value that satisfies `inst?` in `timestamp` shapes [#314](https://github.com/cognitect-labs/aws-api/issues/314)
+
 ## 0.8.838 / 2026-07-07
 
 * Fix test-double in Babashka [#312](https://github.com/cognitect-labs/aws-api/issues/312)

--- a/src/cognitect/aws/util.clj
+++ b/src/cognitect/aws/util.clj
@@ -8,7 +8,7 @@
             [cognitect.aws.util.xml :as util.xml]
             [clojure.java.io :as io]
             [clojure.core.async :as a])
-  (:import [java.time ZoneOffset ZonedDateTime]
+  (:import [java.time Instant ZoneOffset ZonedDateTime]
            [java.time.format DateTimeFormatter]
            [java.util Date]
            [java.util UUID]
@@ -26,13 +26,13 @@
 (defn format-date
   ([fmt]
    (format-date fmt (Date.)))
-  ([^DateTimeFormatter fmt ^Date inst]
-   (.format fmt (.atZone (.toInstant inst) ZoneOffset/UTC))))
+  ([^DateTimeFormatter fmt inst]
+   (.format fmt (.atZone (Instant/ofEpochMilli (inst-ms inst)) ZoneOffset/UTC))))
 
 (defn format-timestamp
   "Format a timestamp in milliseconds."
   [inst]
-  (str (long (/ (.getTime ^Date inst) 1000))))
+  (str (long (/ (inst-ms inst) 1000))))
 
 (defn parse-date
   [^DateTimeFormatter fmt ^String s]

--- a/test/src/cognitect/aws/shape_test.clj
+++ b/test/src/cognitect/aws/shape_test.clj
@@ -38,3 +38,36 @@
          (shape/json-serialize {}
                                {:type "structure", :members {}, :document true}
                                {:this "is" :a "doc"}))))
+
+(deftest format-date-test
+  (testing "java.util.Date values"
+    (let [data #inst "2026-07-29T22:36:35.339-00:00"]
+      (is (= "Wed, 29 Jul 2026 22:36:35 GMT"
+             (shape/format-date {:timestampFormat "rfc822"} data)))
+      (is (= "2026-07-29T22:36:35Z"
+             (shape/format-date {:timestampFormat "iso8601"} data)))
+      (is (= "1785364595"
+             (shape/format-date {:timestampFormat "unixTimestamp"} data)))))
+
+  (testing "java.time.Instant values"
+    (let [data (java.time.Instant/parse "2026-07-29T22:36:35.339Z")]
+      (is (= "Wed, 29 Jul 2026 22:36:35 GMT"
+             (shape/format-date {:timestampFormat "rfc822"} data)))
+      (is (= "2026-07-29T22:36:35Z"
+             (shape/format-date {:timestampFormat "iso8601"} data)))
+      (is (= "1785364595"
+             (shape/format-date {:timestampFormat "unixTimestamp"} data)))))
+
+  (testing "custom protocol extension"
+    (extend-protocol Inst
+      Long
+      (inst-ms* [inst] inst))
+
+    (let [data 1785364595339]
+      (is (inst? data))
+      (is (= "Wed, 29 Jul 2026 22:36:35 GMT"
+             (shape/format-date {:timestampFormat "rfc822"} data)))
+      (is (= "2026-07-29T22:36:35Z"
+             (shape/format-date {:timestampFormat "iso8601"} data)))
+      (is (= "1785364595"
+             (shape/format-date {:timestampFormat "unixTimestamp"} data))))))

--- a/test/src/cognitect/aws/shape_test.cljc
+++ b/test/src/cognitect/aws/shape_test.cljc
@@ -58,16 +58,19 @@
       (is (= "1785364595"
              (shape/format-date {:timestampFormat "unixTimestamp"} data)))))
 
-  (testing "custom protocol extension"
-    (extend-protocol Inst
-      Long
-      (inst-ms* [inst] inst))
+  #?(;; https://github.com/babashka/babashka/issues/1321
+     :bb nil
+     :clj
+     (testing "custom protocol extension"
+       (extend-protocol Inst
+         Long
+         (inst-ms* [inst] inst))
 
-    (let [data 1785364595339]
-      (is (inst? data))
-      (is (= "Wed, 29 Jul 2026 22:36:35 GMT"
-             (shape/format-date {:timestampFormat "rfc822"} data)))
-      (is (= "2026-07-29T22:36:35Z"
-             (shape/format-date {:timestampFormat "iso8601"} data)))
-      (is (= "1785364595"
-             (shape/format-date {:timestampFormat "unixTimestamp"} data))))))
+       (let [data 1785364595339]
+         (is (inst? data))
+         (is (= "Wed, 29 Jul 2026 22:36:35 GMT"
+                (shape/format-date {:timestampFormat "rfc822"} data)))
+         (is (= "2026-07-29T22:36:35Z"
+                (shape/format-date {:timestampFormat "iso8601"} data)))
+         (is (= "1785364595"
+                (shape/format-date {:timestampFormat "unixTimestamp"} data)))))))


### PR DESCRIPTION
The spec for `timestamp` shapes is `inst?`, but the format function only accepted `java.util.Date` values.

Now the format implementation uses `inst-ms`, which aligns with the `inst?` predicate, allowing `java.time.Instant` values and supporting custom extensions of the `Inst` protocol.

Fixes https://github.com/cognitect-labs/aws-api/issues/314
